### PR TITLE
Fix Knockout.ES5 eval bug

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -6,6 +6,7 @@ module.exports = (grunt) ->
             main:
                 dependencies:
                     'pgwmodal': 'zepto'
+                    'knockoutjs': ['underscore', 'zepto']
                     'knockout-es5-passy': ['knockoutjs', 'knockout-secure-binding']
                     'knockout-secure-binding': 'knockoutjs'
                 mainFiles:


### PR DESCRIPTION
Knockout.ES5 で eval が実行されているため、eval 以降がエラーで実行されないバグが Background Pages にあり。修正
