### PR TITLE
Move npm tasks (grunt -> npm)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,9 @@ language: node_js
 node_js:
   - 0.10
 before_script:
-  - npm install -g grunt-cli
-  - npm install -g bower
-  - npm install -g tsd@0.6.0-beta.3
-  - bower --version
-  - tsd --version
-  - bower install
-  - tsd reinstall
+  - node_modules/.bin/grunt --version
+  - node_modules/.bin/bower --version
+  - node_modules/.bin/tsd --version
+  - node_modules/.bin/bower install
+  - node_modules/.bin/tsd reinstall
 script: npm test

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "grunt test"
+    "test": "grunt test",
+    "build": "grunt build",
+    "watch": "grunt watch"
   },
   "author": "",
   "license": "MIT",
@@ -16,8 +18,10 @@
     "content-type": "0.0.1"
   },
   "devDependencies": {
+    "bower": "^1.3.12",
     "grunt": "^0.4.5",
     "grunt-bower-concat": "^0.4.0",
+    "grunt-cli": "^0.1.13",
     "grunt-concat-css": "^0.3.1",
     "grunt-contrib-clean": "^0.6.0",
     "grunt-contrib-compress": "^0.12.0",
@@ -29,6 +33,7 @@
     "grunt-json5-to-json": "^0.1.3",
     "grunt-typescript": "^0.4.0",
     "load-grunt-tasks": "^1.0.0",
+    "tsd": "^0.6.0-beta.4",
     "typescript": "1.3.x",
     "grunt-webstore-upload": "^0.7.2",
     "grunt-crx": "^0.3.3",


### PR DESCRIPTION
タスク類を npm 経由に変更
コンパイルツールのグローバルインストールを排除
